### PR TITLE
Sa items

### DIFF
--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -75,4 +75,13 @@ class MerchantRepository
     array = @se.items.find_all_by_merchant_id(merchant_id)
     array.length
   end
+
+  def return_merchants_by_item_count_greater_than(condition, results = [])
+    @merchants.each do |merchant|
+      if merchant.items.count > condition
+        results << merchant
+      end
+    end
+    results
+  end
 end

--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -63,4 +63,16 @@ class MerchantRepository
     found_merchants
   end
 
+  def get_total_inventory
+    total_inventory_array = []
+    @merchants.each do |merchant|
+      total_inventory_array << merchant_items_count(merchant.id)
+    end
+    total_inventory_array
+  end
+
+  def merchant_items_count(merchant_id)
+    array = @se.items.find_all_by_merchant_id(merchant_id)
+    array.length
+  end
 end

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -47,14 +47,8 @@ class SalesAnalyst
 
   #stay
   def merchants_with_high_item_count
-    deviant_merchants = []
     outlier_threshhold = find_inventory_total_one_std_deviation_above_avrg_std_deviation
-    @se.merchants.all.each do |merchant|
-      if merchant.items.count > outlier_threshhold
-        deviant_merchants << merchant
-      end
-    end
-    deviant_merchants
+    @se.merchants.return_merchants_by_item_count_greater_than(outlier_threshhold)
   end
 
   #live in items

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -7,24 +7,13 @@ class SalesAnalyst
     @se = sales_engine
   end
 
-  #merchant, as well as one below
-  def merchant_items_count(merchant_id)
-    array = @se.items.find_all_by_merchant_id(merchant_id)
-    array.length
-  end
-
-  #merchant, as well as one above it
-  def get_total_inventory
-    total_inventory_array = []
-    @se.merchants.all_ids.each do |id|
-      total_inventory_array << merchant_items_count(id)
-    end
-    total_inventory_array
+  def merchants_total_inventory
+    @se.merchants.get_total_inventory
   end
 
   #stay
   def average_items_per_merchant
-    find_avrg_of_array(get_total_inventory)
+    find_avrg_of_array(merchants_total_inventory)
   end
 
   #stay
@@ -45,15 +34,13 @@ class SalesAnalyst
 
   #stay
   def average_items_per_merchant_standard_deviation
-    total = get_total_inventory
-    find_standard_deviation(total)
+    find_standard_deviation(merchants_total_inventory)
   end
 
   #stay
   def find_inventory_total_one_std_deviation_above_avrg_std_deviation
-    total = get_total_inventory
-    std_dev = find_standard_deviation(total)
-    mean = find_avrg_of_array(total)
+    std_dev = find_standard_deviation(merchants_total_inventory)
+    mean = find_avrg_of_array(merchants_total_inventory)
     outlier_threshhold = std_dev + mean
     outlier_threshhold
   end

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -20,6 +20,10 @@ class MerchantRepositoryTest < Minitest::Test
     assert_instance_of MerchantRepository, @mr
   end
 
+  def test_merchants_all
+    assert_equal 475, @mr.all.count
+  end
+  
   def test_all_returns_all_merchants_in_the_correct_format
     assert_instance_of Merchant, @mr.merchants[0]
     assert_equal 'Shopin1901', @mr.merchants[0].name
@@ -71,5 +75,10 @@ class MerchantRepositoryTest < Minitest::Test
     assert_equal 3, @mr.merchant_items_count(12334105)
     assert_equal 25, @mr.merchant_items_count(12334123)
     assert_equal 0, @mr.merchant_items_count(12334110)
+  end
+
+  def test_return_merchants_by_item_count_greater_than
+    assert_equal 15, @mr.return_merchants_by_item_count_greater_than(10).count
+    assert_equal 9, @mr.return_merchants_by_item_count_greater_than(12).count
   end
 end

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -9,7 +9,10 @@ class MerchantRepositoryTest < Minitest::Test
 # REFACTOR TO USE DUMMY DATA
 
   def setup
-    @se = "not a sales engine"
+    @se = SalesEngine.from_csv({
+        :items     => "./data/items.csv",
+        :merchants => "./data/merchants.csv",
+        })
     @mr = MerchantRepository.new("./data/merchants.csv", @se)
   end
 
@@ -57,5 +60,16 @@ class MerchantRepositoryTest < Minitest::Test
   def test_create_array_of_merchant_ids
     assert_equal 475, @mr.all_ids.count
     assert_instance_of Fixnum, @mr.all_ids[27]
+  end
+
+  def test_get_total_inventory
+    assert_equal 475, @mr.get_total_inventory.count
+    assert_instance_of Fixnum, @mr.get_total_inventory[5]
+  end
+
+  def test_merchant_items_count
+    assert_equal 3, @mr.merchant_items_count(12334105)
+    assert_equal 25, @mr.merchant_items_count(12334123)
+    assert_equal 0, @mr.merchant_items_count(12334110)
   end
 end

--- a/test/sales_analyst_test.rb
+++ b/test/sales_analyst_test.rb
@@ -21,12 +21,6 @@ class SalesAnalystTest < Minitest::Test
     assert_instance_of SalesAnalyst, @sa
   end
 
-  def test_retrieve_number_of_items_for_one_merchant
-    item_count = @sa.merchant_items_count(12334105)
-
-    assert_equal 3, item_count
-  end
-
   def test_find_avrg_items_per_merchant
     assert_equal 2.88, @sa.average_items_per_merchant
   end


### PR DESCRIPTION
Refactored the SA to remove the merchant references along with the corresponding tests.  Let me know if these all make sense.

I'm not sure if the new find_inventory_total_one_std_deviation_above_avrg_std_deviation actually makes things more clear or not.

I also removed  test_retrieve_number_of_items_for_one_merchant test since the refactor doesn't allow us to support giving that method an argument from the MR level.